### PR TITLE
Change Markdown header to sentence case

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -7,7 +7,7 @@ about: Describe an idea, todo, feature, task, improvement, issue, epic, or story
 
 What is the work, as a high-level summary?
 
-## Motivation ##
+## Motivation and context ##
 
 Why does this work belong in this project?
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@
 <!-- Describe the "what" of your changes in detail. -->
 <!-- To avoid scope creep, limit changes to a single goal. -->
 
-## 💭 Motivation and Context ##
+## 💭 Motivation and context ##
 
 <!-- Why is this change required? -->
 <!-- What problem does this change solve? How did you solve it? -->


### PR DESCRIPTION
## 🗣 Description ##

This pull request changes a Markdown header in the pull request template from title case to sentence case.

## 💭 Motivation and Context ##

This change is required to agree with the Markdown style guide in cisagov/development-guide#44.

Resolves #18.

## 🧪 Testing ##

It's a one character change...what could possibly go wrong?

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
