### PR TITLE
Add default repository labels

### DIFF
--- a/repo-labels.json
+++ b/repo-labels.json
@@ -1,0 +1,87 @@
+[
+  {
+    "color": "#eb6420",
+    "description": "This issue or pull request is blocked",
+    "name": "blocked"
+  },
+  {
+    "color": "#000000",
+    "description": "This issue or pull request will cause existing functionality to change",
+    "name": "breaking change"
+  },
+  {
+    "color": "#d73a4a",
+    "description": "This issue or pull request addresses broken functionality",
+    "name": "bug"
+  },
+  {
+    "color": "#07648d",
+    "description": "This issue will be advertised on code.gov's \"Open Tasks\" page (https://code.gov/open-tasks)",
+    "name": "code.gov"
+  },
+  {
+    "color": "#5319e7",
+    "description": "This issue or pull request involves improvements or additions to documentation",
+    "name": "documentation"
+  },
+  {
+    "color": "#cfd3d7",
+    "description": "This issue or pull request already exists",
+    "name": "duplicate"
+  },
+  {
+    "color": "#b005bc",
+    "description": "This issue is an epic",
+    "name": "epic"
+  },
+  {
+    "color": "#0e8a16",
+    "description": "Good for newcomers",
+    "name": "good first issue"
+  },
+  {
+    "color": "#a2eeef",
+    "description": "This issue or pull request will add new or improve existing functionality",
+    "name": "improvement"
+  },
+  {
+    "color": "#fef2c0",
+    "description": "This doesn't seem right",
+    "name": "invalid"
+  },
+  {
+    "color": "#ce099a",
+    "description": "This pull request is ready to merge during the next Lineage kraken release",
+    "name": "Kraken"
+  },
+  {
+    "color": "#fcdb45",
+    "description": "This issue or pull request requires further information",
+    "name": "need info"
+  },
+  {
+    "color": "#a4fc5d",
+    "description": "This pull request is awaiting an action or decision to move forward",
+    "name": "on hold"
+  },
+  {
+    "color": "#ef476c",
+    "description": "Further information is requested",
+    "name": "question"
+  },
+  {
+    "color": "#1d76db",
+    "description": "This issue or pull request relates to pulling in upstream updates",
+    "name": "upstream update"
+  },
+  {
+    "color": "#d4c5f9",
+    "description": "This issue or pull request involves a version bump",
+    "name": "version bump"
+  },
+  {
+    "color": "#ffffff",
+    "description": "This issue will not be worked on ",
+    "name": "wontfix"
+  }
+]


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

Adds a file to use as configuration for GitHub label standardization using https://github.com/cisagov/github-label-management

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

New repositories inherit labels from the `.github` repository, so using the tool and updating this `.github` repository will keep this repository and both new and old repos updated.

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

This was the file I used last year when standardizing repository labels, before I left 😭 . This will wrap up the work.

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
